### PR TITLE
Add options global.imageRegistry and extraTls to Chart

### DIFF
--- a/charts/dokuwiki/README.md
+++ b/charts/dokuwiki/README.md
@@ -36,7 +36,8 @@ helm install dokuwiki area-42/dokuwiki
 | extraEmptyDirMounts | list | `[]` | This allows you to mount additional "emptyDirs" into the DokuWiki container |
 | extraVolumeMounts | list | `[]` | This allows you to mount additional volumes into the DokuWiki container |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
-| image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |
+| fullnameOverride | string | `""` | String to override the default generated fullname |
+| global.imageRegistry | string | `""` | Optional registry to pull all images from. eg. `myregistry.acme.com/` - trailing slash is required when specifed |
 | image.repository | string | `"dokuwiki/dokuwiki"` | The docker image repository to use |
 | image.tag | string | vhart appVersion | The docker image tag to use |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/dokuwiki/README.md
+++ b/charts/dokuwiki/README.md
@@ -38,6 +38,7 @@ helm install dokuwiki area-42/dokuwiki
 | fullnameOverride | string | `""` | String to override the default generated fullname |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
 | global.imageRegistry | string | `""` | Optional registry to pull all images from. eg. `myregistry.acme.com/` - trailing slash is required when specifed |
+| image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |
 | image.repository | string | `"dokuwiki/dokuwiki"` | The docker image repository to use |
 | image.tag | string | vhart appVersion | The docker image tag to use |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/dokuwiki/README.md
+++ b/charts/dokuwiki/README.md
@@ -36,7 +36,6 @@ helm install dokuwiki area-42/dokuwiki
 | extraEmptyDirMounts | list | `[]` | This allows you to mount additional "emptyDirs" into the DokuWiki container |
 | extraVolumeMounts | list | `[]` | This allows you to mount additional volumes into the DokuWiki container |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
-| fullnameOverride | string | `""` | String to override the default generated fullname |
 | global.imageRegistry | string | `""` | Optional registry to pull all images from. eg. `myregistry.acme.com/` - trailing slash is required when specifed |
 | image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |
 | image.repository | string | `"dokuwiki/dokuwiki"` | The docker image repository to use |

--- a/charts/dokuwiki/README.md
+++ b/charts/dokuwiki/README.md
@@ -47,6 +47,7 @@ helm install dokuwiki area-42/dokuwiki
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` | Ingress tls |
+| ingress.extraTls | object | `{}` | Extra definition to place below the ingress tls subkey |
 | nameOverride | string | `""` | String to override the default generated name |
 | nodeSelector | object | `{}` | Set the node selector for the pod. |
 | persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |

--- a/charts/dokuwiki/templates/deployment.yaml
+++ b/charts/dokuwiki/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           volumeMounts:
             - name: dokuwiki-storage
               mountPath: "/storage"

--- a/charts/dokuwiki/templates/ingress.yaml
+++ b/charts/dokuwiki/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:
@@ -34,6 +34,9 @@ spec:
         - {{ . | quote }}
         {{- end }}
       secretName: {{ .secretName }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/dokuwiki/templates/tests/test-connection.yaml
+++ b/charts/dokuwiki/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: {{ .Values.global.imageRegistry }}busybox
       command: ['wget']
       args: ['{{ include "dokuwiki.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/dokuwiki/values.yaml
+++ b/charts/dokuwiki/values.yaml
@@ -70,6 +70,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  extraTls: {}
 
 dokuwiki:
   admin:

--- a/charts/dokuwiki/values.yaml
+++ b/charts/dokuwiki/values.yaml
@@ -75,7 +75,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  extraTls: {}
+  extraTls: []
 
 
 dokuwiki:

--- a/charts/dokuwiki/values.yaml
+++ b/charts/dokuwiki/values.yaml
@@ -1,3 +1,8 @@
+global:
+  imageRegistry: ""
+  # Optional registry to pull all images from. eg. 'myregistry.acme.com/'
+  # trailing slash is required when specifed
+  
 # Default values for dokuwiki.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -71,6 +76,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
   extraTls: {}
+
 
 dokuwiki:
   admin:


### PR DESCRIPTION
Hello!

To use the chart in our company i had to add two options.

- The option `global.imageRegistry` allows to specify a private registry for both - dokuwiki and test-connection pod.
- The option `extraTls` allows additional configuration options for tls. E.g Use of an wildcard certificate.

Best regards 
Sönke