### PR TITLE
limesurvey: have probes be configurable as values

### DIFF
--- a/charts/limesurvey/templates/deployment.yaml
+++ b/charts/limesurvey/templates/deployment.yaml
@@ -157,45 +157,15 @@ spec:
               protocol: TCP
           {{- if .Values.limesurvey.startupProbe.enabled }}
           startupProbe:
-            httpGet:
-              path: /
-              port: http
-              httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-            initialDelaySeconds: {{ .Values.limesurvey.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.limesurvey.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.limesurvey.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.limesurvey.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.limesurvey.startupProbe.failureThreshold }}
+            {{- omit .Values.limesurvey.startupProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.limesurvey.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
-              httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-            initialDelaySeconds: {{ .Values.limesurvey.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.limesurvey.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.limesurvey.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.limesurvey.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.limesurvey.livenessProbe.failureThreshold }}
+            {{- omit .Values.limesurvey.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.limesurvey.readinessProbe.enabled }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
-              httpHeaders:
-              - name: X-Forwarded-Proto
-                value: https
-            initialDelaySeconds: {{ .Values.limesurvey.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.limesurvey.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.limesurvey.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.limesurvey.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.limesurvey.readinessProbe.failureThreshold }}
+            {{- omit .Values.limesurvey.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/limesurvey/values.yaml
+++ b/charts/limesurvey/values.yaml
@@ -134,6 +134,12 @@ limesurvey:
 
   startupProbe:
     enabled: true
+    httpGet:
+      path: /
+      port: http
+      httpHeaders:
+      - name: X-Forwarded-Proto
+        value: https
     initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 1
@@ -142,6 +148,12 @@ limesurvey:
 
   livenessProbe:
     enabled: true
+    httpGet:
+      path: /
+      port: http
+      httpHeaders:
+      - name: X-Forwarded-Proto
+        value: https
     initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 1
@@ -150,6 +162,12 @@ limesurvey:
 
   readinessProbe:
     enabled: true
+    httpGet:
+      path: /
+      port: http
+      httpHeaders:
+      - name: X-Forwarded-Proto
+        value: https
     initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 1


### PR DESCRIPTION
## Changes

This PR moves all probe settings (`startupProbe`, `livenessProbe` and `readinessProbe`) to the values, so that, one can override them. 

### Background

Using root `/` as a path for the probes, causes the creation of php sessions with every probe request. A better approach would be to have a healthcheck endpoint that doesn't create php sessions with every request. For that, we need to be able to define `httpGet.path`.

I was able to prevent the creation of infinite session files by the probes by creating a healthcheck script `healthz.php`:

```php
<?php
http_response_code(200);
echo "OK";
```

Then changing the probes path to:

```yaml
  httpGet:
      path: /healthz.php
```

The healthcheck script can be mounted from a ConfigMap. The ConfigMap can be easily added to the deployment using the `extarDeploy` option added in PR: https://github.com/area-42/helm-charts/pull/7