### PR TITLE
limesurvey: fix extraobjects template

### DIFF
--- a/charts/limesurvey/templates/extraobjects.yaml
+++ b/charts/limesurvey/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraDeploy }}
 ---
-{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{ . | nindent 0 }}
 {{- end }}


### PR DESCRIPTION
Sorry, I've made a mistake in my previous PR in the template for `extraobjects.yaml` (I used the bitnami common chart as a dependency). This is the correct version without the common dependency :) 